### PR TITLE
Fix `NilClass` method error

### DIFF
--- a/lib/jekyll-server-redirects/command.rb
+++ b/lib/jekyll-server-redirects/command.rb
@@ -26,7 +26,7 @@ module Jekyll
           redirects = Array.new
           custom_redirects = site.config['custom_redirects'] || Array.new
 
-          site.config['custom_redirects'].each do |conf|
+          custom_redirects.each do |conf|
             puts "config: #{conf}"
           end
 
@@ -36,7 +36,7 @@ module Jekyll
             r
           end
 
-          site.config['custom_redirects'].each do |conf|
+          custom_redirects.each do |conf|
             puts "config: #{conf}"
           end
 


### PR DESCRIPTION
When using this gem with a site that does not define any custom
redirects in the configuration file, it tries to call the method
`each` on a `nil` it gets by looking up `custom_redirects` in the
config file.  Instead, we want to use the local variable we created
to check for this specific case, instead of looking it up again.
